### PR TITLE
fix bug with recursive aptitude update

### DIFF
--- a/definitions/apt-repo.rb
+++ b/definitions/apt-repo.rb
@@ -43,16 +43,16 @@ define :apt_repo,
   file_content = "deb     #{src_entry}\n"
   file_content << "deb-src #{src_entry}\n" if params[:source_packages]
 
+  execute "aptitude update" do
+    action :nothing
+  end
+
   directory "/etc/apt/sources.list.d"
-  file "repo.list" do
+  file "#{params[:name]}.list" do
     path "/etc/apt/sources.list.d/#{params[:name]}.list"
     content file_content
     mode "0644"
-  end
-
-  execute "aptitude update" do
-    action :nothing
-    subscribes :run, resources(:file => "repo.list"), :immediately
+    notifies :run, resources(:execute => "aptitude update"), :immediately
   end
 
   if params[:key_package]


### PR DESCRIPTION
We once talked about a bug where "aptitude update" was called way to many times. It seems that the file name "repo.list" was the actual problem.
With subscribing the exec to "repo.list" it was called recursively. So the second repo that occurs called "aptitude update" for itself and the first repo resulting in way to many update runs (with 7 repos I had 28 update runs).
So changeing the file name was the one thing, and then the subscribe was really ugly with a variable so I changed it to a notify for the file.
