### PR TITLE
removed unnecessary doubled `apt-get update`

### DIFF
--- a/definitions/apt-repo.rb
+++ b/definitions/apt-repo.rb
@@ -38,10 +38,6 @@ define :apt_repo,
     end
   end
 
-  execute "apt-get update" do
-    action :nothing
-  end
-
   directory "/etc/apt/sources.list.d"
 
   src_entry = "#{params[:url]} #{distribution} #{components} ##{description}"


### PR DESCRIPTION
apt gets updated by `notifies :run, resources(:execute => "apt-get update"), :immediately`
